### PR TITLE
escape interpreted tags in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Allow multiline strings:
 
 <pre>
 html = "
-<body>
-<h1>SOY SAUCE</h1>
-</body>
+&lt;body>
+&lt;h1>SOY SAUCE&lt;/h1>
+&lt;/body>
 "
 </pre>
 


### PR DESCRIPTION
The README.md file has HTML tags in it that are being interpreted. They need to be escaped.
