### PR TITLE
Add missing optparse dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lib" : "./lib"
   },
   "repository": "http://github.com/weepy/kaffeine",
-  "dependencies": { "brequire": ">= 0.0.2"},
+  "dependencies": { "brequire": ">= 0.0.2", "optparse": "1.0.1" },
   "engines" : { "node": ">= 0.3.0" },
   "main": "./lib/index.js"
 }


### PR DESCRIPTION
Just tried out kaffeine for the first time, got got this error after installing with npm install -g kaffeine:

```
$ kaffeine

node.js:134
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
Error: Cannot find module 'optparse'
    at Function._resolveFilename (module.js:320:11)
    at Function._load (module.js:266:25)
    at require (module.js:348:19)
    at Object.<anonymous> (/usr/local/lib/node_modules/kaffeine/lib/command.js:4:22)
    at Module._compile (module.js:404:26)
    at Object..js (module.js:410:10)
    at Module.load (module.js:336:31)
    at Function._load (module.js:297:12)
    at require (module.js:348:19)
```

The attached patch should fix this.

I'd also love to chat about kaffeine at some point, after having tried out coffeescript, I seriously consider giving this a try. Compatibility with JS, matching line number and the bang syntax are just awesome.
